### PR TITLE
Add "/error" to authorized http requests

### DIFF
--- a/src/main/java/com/bibliotech/security/config/SecurityConfiguration.java
+++ b/src/main/java/com/bibliotech/security/config/SecurityConfiguration.java
@@ -52,6 +52,7 @@ public class SecurityConfiguration {
                 .authorizeHttpRequests(request ->
                         request
                                 .requestMatchers("/api/v1/auth/**").permitAll()
+                                .requestMatchers("/error").permitAll()
                                 .anyRequest().authenticated()
                 )
                 .sessionManagement(manager -> manager.sessionCreationPolicy(STATELESS))


### PR DESCRIPTION
Workaround to avoid 403 in POST methods